### PR TITLE
Fix build on Linux: "error: use of undeclared identifier 'memcpy'"

### DIFF
--- a/src/CDI/cores/DS1216/DS1216.cpp
+++ b/src/CDI/cores/DS1216/DS1216.cpp
@@ -3,6 +3,7 @@
 #include "../../common/utils.hpp"
 
 #include <algorithm>
+#include <cstring>
 
 enum DS1216Clock
 {


### PR DESCRIPTION
Without this, it fails with:

	/home/martin/code/laser/CeDImu/src/CDI/cores/DS1216/DS1216.cpp:66:5: error: use of undeclared identifier 'memcpy'; did you mean 'wmemcpy'?
		memcpy(nv, sram.data(), sram.size());
		^~~~~~
		wmemcpy

	/usr/include/wchar.h:262:17: note: 'wmemcpy' declared here
	extern wchar_t *wmemcpy (wchar_t *__restrict __s1,
					^

Note: I'm not a C++ programmer – I have no idea if this will break stuff on
other systems, or even if it's the "correct" way to fix it. But it does work for
me and gave me a working "CeDImu" binary.

This is with clang 12.0.0 – I didn't try gcc.