### PR TITLE
Compile fixes for macOS and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ make -j$(nproc --all)
 
 If you want to have the memory access logs, replace `cmake ..` with `cmake .. -DENABLE_LOG=1`
 
+#### macOS
+
+Package dependency: `wxwidgets` and `cmake` (e.g. if using brew run: `brew install wxwidgets cmake`). Also make sure to have Xcode or just it's Command Line Tools installed.
+
+For keyboard input to work properly, enable 'Keyboard Navigation' in macOS. See this [support article](https://support.apple.com/en-us/HT204434#fullkeyboard).
+
+Open a terminal in the root directory of the git and type:
+
+```sh
+mkdir build
+cd build
+cmake ..
+make -j$(sysctl -n hw.physicalcpu)
+```
+
 ## libCeDImu
 
 If I get everything listed upper working, stable and fully functional, the goal is to create libCeDImu, a complete library (static and/or dynamic) to allow any program to implement CDI applications (other emulators like Bizhawk, MAME, etc).

--- a/src/CDI/cores/MC68HC05/M68000Interface.hpp
+++ b/src/CDI/cores/MC68HC05/M68000Interface.hpp
@@ -22,16 +22,16 @@ public:
 
     void Reset();
 
-    [[nodiscard]] uint8_t PopByteMCU(size_t channel);
-    [[nodiscard]] bool PushByteMCU(size_t channel, uint8_t data);
-    [[nodiscard]] uint8_t GetStatusMCU(size_t channel);
+    [[nodiscard]] uint8_t PopByteMCU(std::size_t channel);
+    [[nodiscard]] bool PushByteMCU(std::size_t channel, uint8_t data);
+    [[nodiscard]] uint8_t GetStatusMCU(std::size_t channel);
     [[nodiscard]] uint8_t GetInterruptStatusMCU();
     [[nodiscard]] uint8_t GetInterruptMaskMCU();
     void SetInterruptMaskMCU(uint8_t value);
 
-    [[nodiscard]] uint8_t PopByteHost(size_t channel);
-    [[nodiscard]] bool PushByteHost(size_t channel, uint8_t data);
-    [[nodiscard]] uint8_t GetStatusHost(size_t channel);
+    [[nodiscard]] uint8_t PopByteHost(std::size_t channel);
+    [[nodiscard]] bool PushByteHost(std::size_t channel, uint8_t data);
+    [[nodiscard]] uint8_t GetStatusHost(std::size_t channel);
     [[nodiscard]] uint8_t GetInterruptStatusHost();
     [[nodiscard]] uint8_t GetInterruptMaskHost();
     void SetInterruptMaskHost(uint8_t value);
@@ -47,8 +47,8 @@ private:
     uint8_t modeHost;
 
     void ClearChannels();
-    bool ChannelEnabledMCU(size_t channel);
-    bool ChannelEnabledHost(size_t channel);
+    bool ChannelEnabledMCU(std::size_t channel);
+    bool ChannelEnabledHost(std::size_t channel);
 
     enum RegistersFlags
     {

--- a/src/CDI/cores/MC68HC05/M68000Interface.hpp
+++ b/src/CDI/cores/MC68HC05/M68000Interface.hpp
@@ -2,6 +2,7 @@
 #define CDI_CORES_MC68HC05_M68000INTERFACE_HPP
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 
@@ -22,16 +23,16 @@ public:
 
     void Reset();
 
-    [[nodiscard]] uint8_t PopByteMCU(std::size_t channel);
-    [[nodiscard]] bool PushByteMCU(std::size_t channel, uint8_t data);
-    [[nodiscard]] uint8_t GetStatusMCU(std::size_t channel);
+    [[nodiscard]] uint8_t PopByteMCU(size_t channel);
+    [[nodiscard]] bool PushByteMCU(size_t channel, uint8_t data);
+    [[nodiscard]] uint8_t GetStatusMCU(size_t channel);
     [[nodiscard]] uint8_t GetInterruptStatusMCU();
     [[nodiscard]] uint8_t GetInterruptMaskMCU();
     void SetInterruptMaskMCU(uint8_t value);
 
-    [[nodiscard]] uint8_t PopByteHost(std::size_t channel);
-    [[nodiscard]] bool PushByteHost(std::size_t channel, uint8_t data);
-    [[nodiscard]] uint8_t GetStatusHost(std::size_t channel);
+    [[nodiscard]] uint8_t PopByteHost(size_t channel);
+    [[nodiscard]] bool PushByteHost(size_t channel, uint8_t data);
+    [[nodiscard]] uint8_t GetStatusHost(size_t channel);
     [[nodiscard]] uint8_t GetInterruptStatusHost();
     [[nodiscard]] uint8_t GetInterruptMaskHost();
     void SetInterruptMaskHost(uint8_t value);
@@ -47,8 +48,8 @@ private:
     uint8_t modeHost;
 
     void ClearChannels();
-    bool ChannelEnabledMCU(std::size_t channel);
-    bool ChannelEnabledHost(std::size_t channel);
+    bool ChannelEnabledMCU(size_t channel);
+    bool ChannelEnabledHost(size_t channel);
 
     enum RegistersFlags
     {

--- a/src/CDI/cores/MC68HC05/MC68HC05.cpp
+++ b/src/CDI/cores/MC68HC05/MC68HC05.cpp
@@ -1287,11 +1287,11 @@ void MC68HC05::ASR(uint16_t addr)
     SetMemory(addr, data);
 }
 
-template<int BIT>
+template<int BITNUM>
 void MC68HC05::BCLR()
 {
     const uint8_t addr = GetNextByte();
-    SetMemory(addr, GetMemory(addr) & ~(1 << BIT));
+    SetMemory(addr, GetMemory(addr) & ~(1 << BITNUM));
 }
 
 uint8_t MC68HC05::BIT(uint8_t rhs)
@@ -1309,31 +1309,31 @@ void MC68HC05::Branch(bool condition)
         PC += offset;
 }
 
-template<int BIT>
+template<int BITNUM>
 void MC68HC05::BRCLR()
 {
     const uint8_t addr = GetNextByte();
     const int8_t offset = GetNextByte();
-    CCR[CCRC] = GetMemory(addr) & (1 << BIT);
+    CCR[CCRC] = GetMemory(addr) & (1 << BITNUM);
     if(!CCR[CCRC])
         PC += offset;
 }
 
-template<int BIT>
+template<int BITNUM>
 void MC68HC05::BRSET()
 {
     const uint8_t addr = GetNextByte();
     const int8_t offset = GetNextByte();
-    CCR[CCRC] = GetMemory(addr) & (1 << BIT);
+    CCR[CCRC] = GetMemory(addr) & (1 << BITNUM);
     if(CCR[CCRC])
         PC += offset;
 }
 
-template<int BIT>
+template<int BITNUM>
 void MC68HC05::BSET()
 {
     const uint8_t addr = GetNextByte();
-    SetMemory(addr, GetMemory(addr) | (1 << BIT));
+    SetMemory(addr, GetMemory(addr) | (1 << BITNUM));
 }
 
 void MC68HC05::CLR(uint8_t& reg)

--- a/src/CDI/cores/MC68HC05/MC68HC05.hpp
+++ b/src/CDI/cores/MC68HC05/MC68HC05.hpp
@@ -86,12 +86,12 @@ private:
     void AND(uint8_t rhs);
     void ASR(uint8_t& reg);
     void ASR(uint16_t addr);
-    template<int BIT> void BCLR();
+    template<int BITNUM> void BCLR();
     uint8_t BIT(uint8_t rhs);
     void Branch(bool condition);
-    template<int BIT> void BRCLR();
-    template<int BIT> void BRSET();
-    template<int BIT> void BSET();
+    template<int BITNUM> void BRCLR();
+    template<int BITNUM> void BRSET();
+    template<int BITNUM> void BSET();
     void CLR(uint8_t& reg);
     void CLR(uint16_t addr);
     uint8_t CMP(uint8_t lhs, uint8_t rhs);


### PR DESCRIPTION
This PR fixes a few compile errors on macOS (clang 14.0) and Linux (Ubuntu 22.04 with gcc):

- [MC68HC05.cpp]: error: reference to non-static member function must be called
It looks like clang confused the template parameter name which was `BIT` with the `BIT` method
- [M68000Interface.hpp]: error: size_t has not been declared

Additionally I added all of the steps I had to take to the `README.md`.

Any feedback is welcome, happy to make any changes if needed.